### PR TITLE
Update Discord user linking to support pings

### DIFF
--- a/Requestrr.WebApi/RequestrrBot/DownloadClients/Ombi/OmbiClient.cs
+++ b/Requestrr.WebApi/RequestrrBot/DownloadClients/Ombi/OmbiClient.cs
@@ -556,7 +556,7 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Ombi
                     await notifResponse.ThrowIfNotSuccessfulAsync("OmbiFindUserNotificationPreferences failed", x => x.error);
 
                     IEnumerable<dynamic> notificationPreferences = JArray.Parse(jsonNotifResponse);
-                    var matchingDiscordNotification = notificationPreferences.FirstOrDefault(n => n.agent == 1 && n.value.ToString().Trim().Equals(userUniqueId.Trim(), StringComparison.InvariantCultureIgnoreCase));
+                    var matchingDiscordNotification = notificationPreferences.FirstOrDefault(n => n.agent == 1 && (n.value.ToString().Trim().Equals(userUniqueId.Trim(), StringComparison.InvariantCultureIgnoreCase) || n.value.ToString().Trim().Equals($"<@{userUniqueId.Trim()}>", StringComparison.InvariantCultureIgnoreCase)));
 
                     if (matchingDiscordNotification != null)
                     {


### PR DESCRIPTION
Current version only supports checking if the Notification Preference is solely the user id, but some Notification Preferences will specifically be a ping `<@id>` instead.