### PR TITLE
Build the entire app using multi-stage builds

### DIFF
--- a/Requestrr.WebApi/dockerfile
+++ b/Requestrr.WebApi/dockerfile
@@ -1,6 +1,28 @@
+FROM node AS node-build
+
+COPY ClientApp /app
+
+WORKDIR /app
+
+RUN npm install
+
+RUN npm run build
+
+FROM mcr.microsoft.com/dotnet/sdk:6.0 as dotnet-build
+
+RUN apt-get update && \
+  apt-get --no-install-recommends -y install nodejs npm
+
+COPY ./ /app
+COPY --from=node-build /app /app/ClientApp
+
+WORKDIR /app
+
+RUN dotnet publish -c release -o publish -r linux-x64 Requestrr.WebApi.csproj
+
 FROM mcr.microsoft.com/dotnet/aspnet:6.0
 
-COPY publish/ /root/
+COPY --from=dotnet-build /app/publish/ /root/
 
 # allow all users access to this so we can run container as non root.
 # create /root/tmp if nonexistent

--- a/Requestrr.WebApi/dockerfile
+++ b/Requestrr.WebApi/dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 RUN npm run build
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 as dotnet-build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 as dotnet-build
 
 RUN apt-get update && \
   apt-get --no-install-recommends -y install nodejs npm
@@ -18,15 +18,18 @@ COPY --from=node-build /app /app/ClientApp
 
 WORKDIR /app
 
-RUN dotnet publish -c release -o publish -r linux-x64 Requestrr.WebApi.csproj
+RUN dotnet publish -c release -o publish Requestrr.WebApi.csproj
+RUN rm -rf /app/publish/config
+RUN rm -rf /app/publish/tmp
+RUN mkdir /app/publish/config
+RUN rm -f /app/publish/appsettings.Development.json
 
 FROM mcr.microsoft.com/dotnet/aspnet:6.0
 
 COPY --from=dotnet-build /app/publish/ /root/
 
 # allow all users access to this so we can run container as non root.
-# create /root/tmp if nonexistent
-RUN chmod -R 755 /root && mkdir /root/tmp && chmod -R 777 /root/tmp
+RUN chmod -R 755 /root
 
 WORKDIR /root/
 


### PR DESCRIPTION
This updates the dockerfile to do [multi-stage builds](https://docs.docker.com/build/building/multi-stage/)

- builds the frontend client using a `node` base
- builds the app using `dotnet/sdk`
- finally, copies the build to run on `dotnet/aspnet` like the dockerfile already did

Now `docker buildx -t myrepo/myimage .` handles everything, eliminating the need to install any dotnet runtime or sdks locally just to create a fresh image