### PR TITLE
Add `MediaUrl` support for Jellyseerr

### DIFF
--- a/Requestrr.WebApi/RequestrrBot/ChatClients/Discord/DiscordMovieUserInterface.cs
+++ b/Requestrr.WebApi/RequestrrBot/ChatClients/Discord/DiscordMovieUserInterface.cs
@@ -237,6 +237,7 @@ namespace Requestrr.WebApi.RequestrrBot.ChatClients.Discord
 
             if (!string.IsNullOrWhiteSpace(movie.PlexUrl)) embedBuilder.AddField($"__Plex__", $"[{Language.Current.DiscordEmbedMovieWatchNow}]({movie.PlexUrl})", true);
             if (!string.IsNullOrWhiteSpace(movie.EmbyUrl)) embedBuilder.AddField($"__Emby__", $"[{Language.Current.DiscordEmbedMovieWatchNow}]({movie.EmbyUrl})", true);
+            if (!string.IsNullOrWhiteSpace(movie.MediaUrl)) embedBuilder.AddField($"__Media__", $"[{Language.Current.DiscordEmbedMovieWatchNow}]({movie.MediaUrl})", true);
 
             return embedBuilder.Build();
         }

--- a/Requestrr.WebApi/RequestrrBot/ChatClients/Discord/DiscordTvShowUserInterface.cs
+++ b/Requestrr.WebApi/RequestrrBot/ChatClients/Discord/DiscordTvShowUserInterface.cs
@@ -51,6 +51,7 @@ namespace Requestrr.WebApi.RequestrrBot.ChatClients.Discord
             if (!string.IsNullOrWhiteSpace(tvShow.Quality)) embedBuilder.AddField($"__{Language.Current.DiscordEmbedTvQuality}__", $"{tvShow.Quality}p", true);
             if (!string.IsNullOrWhiteSpace(tvShow.PlexUrl)) embedBuilder.AddField($"__Plex__", $"[{Language.Current.DiscordEmbedTvWatchNow}]({tvShow.PlexUrl})", true);
             if (!string.IsNullOrWhiteSpace(tvShow.EmbyUrl)) embedBuilder.AddField($"__Emby__", $"[{Language.Current.DiscordEmbedTvWatchNow}]({tvShow.EmbyUrl})", true);
+            if (!string.IsNullOrWhiteSpace(tvShow.MediaUrl)) embedBuilder.AddField($"__Media__", $"[{Language.Current.DiscordEmbedTvWatchNow}]({tvShow.MediaUrl})", true);
 
             return embedBuilder.Build();
         }

--- a/Requestrr.WebApi/RequestrrBot/DownloadClients/Overseerr/OverseerrClient.cs
+++ b/Requestrr.WebApi/RequestrrBot/DownloadClients/Overseerr/OverseerrClient.cs
@@ -910,6 +910,7 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Overseerr
                     || mediaStatus == MediaStatus.PARTIALLY_AVAILABLE
                     || mediaStatus == MediaStatus.AVAILABLE,
                 PlexUrl = jsonMedia.MediaInfo?.PlexUrl,
+                MediaUrl = jsonMedia.MediaInfo?.MediaUrl,
                 Overview = jsonMedia.Overview,
                 PosterPath = !string.IsNullOrWhiteSpace(jsonMedia.PosterPath) ? $"https://image.tmdb.org/t/p/w500{jsonMedia.PosterPath}" : null,
                 ReleaseDate = jsonMedia.ReleaseDate,
@@ -942,6 +943,7 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Overseerr
                 Quality = string.Empty,
                 WebsiteUrl = jsonMedia.TvdbId != null && jsonMedia.TvdbId.ToString() != "0" ? $"https://www.thetvdb.com/?id={jsonMedia.TvdbId}&tab=series" : null,
                 PlexUrl = jsonMedia.MediaInfo?.PlexUrl,
+                MediaUrl = jsonMedia.MediaInfo?.MediaUrl,
                 Overview = jsonMedia.Overview,
                 HasEnded = !jsonMedia.InProduction,
                 Network = jsonMedia.Networks.FirstOrDefault()?.Name,
@@ -1332,6 +1334,9 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Overseerr
 
             [JsonProperty("plexUrl")]
             public string PlexUrl { get; set; }
+
+            [JsonProperty("mediaUrl")]
+            public string MediaUrl { get; set; }
 
             [JsonProperty("seasons")]
             public List<JSONTvSeason> Seasons { get; set; }

--- a/Requestrr.WebApi/RequestrrBot/Movies/Movie.cs
+++ b/Requestrr.WebApi/RequestrrBot/Movies/Movie.cs
@@ -10,6 +10,7 @@ namespace Requestrr.WebApi.RequestrrBot.Movies
         public bool Requested { get; set; }
         public string PlexUrl { get; set; }
         public string EmbyUrl { get; set; }
+        public string MediaUrl { get; set; }
         public string Overview { get; set; }
         public string PosterPath { get; set; }
         public string ReleaseDate { get; set; }

--- a/Requestrr.WebApi/RequestrrBot/TvShows/TvShow.cs
+++ b/Requestrr.WebApi/RequestrrBot/TvShows/TvShow.cs
@@ -19,6 +19,7 @@ namespace Requestrr.WebApi.RequestrrBot.TvShows
         public bool HasEnded { get; set; }
         public string PlexUrl { get; set; }
         public string EmbyUrl { get; set; }
+        public string MediaUrl { get; set; }
         public string Overview { get; set; }
         public string Banner { get; set; }
         public string FirstAired { get; set; }


### PR DESCRIPTION
Jellyseer doesn't use the `plexUrl` key, it uses `mediaUrl`. This PR just adds basic support for that key.