### PR TITLE
feat: Add configurable diagnostic logging via environment variable

### DIFF
--- a/Requestrr.WebApi/Program.cs
+++ b/Requestrr.WebApi/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Requestrr.WebApi.config;
 using Requestrr.WebApi.RequestrrBot;
 using Requestrr.WebApi.RequestrrBot.Locale;
 
@@ -20,6 +21,7 @@ namespace Requestrr.WebApi
     {
         public static int Port = 4545;
         public static string BaseUrl = string.Empty;
+        public static DiagnosticsSettings DiagnosticsSettings = new DiagnosticsSettings();
 
         public static void Main(string[] args)
         {
@@ -29,6 +31,16 @@ namespace Requestrr.WebApi
             if (int.TryParse(Environment.GetEnvironmentVariable("REQUESTRR_PORT"), out int portFromEnv))
             {
                 cliPort = portFromEnv;
+            }
+
+            // Read diagnostic level from environment variable
+            var diagnosticsLevel = Environment.GetEnvironmentVariable("REQUESTRR_DIAGNOSTICS_LEVEL");
+            if (!string.IsNullOrWhiteSpace(diagnosticsLevel))
+            {
+                if (Enum.TryParse<DiagnosticsLevel>(diagnosticsLevel, true, out var level))
+                {
+                    DiagnosticsSettings.Level = level;
+                }
             }
 
             for (int i = 0; i < args.Length; i++)

--- a/Requestrr.WebApi/RequestrrBot/ChatBot.cs
+++ b/Requestrr.WebApi/RequestrrBot/ChatBot.cs
@@ -221,7 +221,7 @@ namespace Requestrr.WebApi.RequestrrBot
                             var slashCommandType = SlashCommandBuilder.Build(_logger, newSettings, _serviceProvider.Get<RadarrSettingsProvider>(), _serviceProvider.Get<SonarrSettingsProvider>(), _serviceProvider.Get<OverseerrSettingsProvider>(), _serviceProvider.Get<OmbiSettingsProvider>(), _serviceProvider.Get<LidarrSettingsProvider>());
 
                             var guildCount = _client.Guilds.Count;
-                            _logger.LogInformation($"Starting slash command registration for {guildCount} guilds");
+                            _logger.LogDiscordSlashCommand(Program.DiagnosticsSettings, $"Starting slash command registration for {guildCount} guilds");
                             var registrationStopwatch = Stopwatch.StartNew();
 
                             if (newSettings.EnableRequestsThroughDirectMessages)
@@ -229,7 +229,7 @@ namespace Requestrr.WebApi.RequestrrBot
                                 try
                                 {
                                     _slashCommands.RegisterCommands(slashCommandType);
-                                    _logger.LogInformation("Registered global slash commands");
+                                    _logger.LogDiscordSlashCommand(Program.DiagnosticsSettings, "Registered global slash commands");
                                 }
                                 catch (System.Exception ex) { _logger.LogError(ex, "Error while registering global slash commands: " + ex.Message); }
 
@@ -241,7 +241,7 @@ namespace Requestrr.WebApi.RequestrrBot
                                     try
                                     {
                                         _slashCommands.RegisterCommands<EmptySlashCommands>(guildId);
-                                        _logger.LogInformation($"Emptied guild-specific slash commands for guild {guildId}");
+                                        _logger.LogDiscordSlashCommand(Program.DiagnosticsSettings, $"Emptied guild-specific slash commands for guild {guildId}");
                                     }
                                     catch (System.Exception ex) { _logger.LogError(ex, $"Error while emptying guild-specific slash commands for guild {guildId}: " + ex.Message); }
 
@@ -254,7 +254,7 @@ namespace Requestrr.WebApi.RequestrrBot
                                 try
                                 {
                                     _slashCommands.RegisterCommands<EmptySlashCommands>();
-                                    _logger.LogInformation("Emptied global slash commands");
+                                    _logger.LogDiscordSlashCommand(Program.DiagnosticsSettings, "Emptied global slash commands");
                                 }
                                 catch (System.Exception ex) { _logger.LogError(ex, "Error while emptying global slash commands: " + ex.Message); }
 
@@ -266,7 +266,7 @@ namespace Requestrr.WebApi.RequestrrBot
                                     try
                                     {
                                         _slashCommands.RegisterCommands(slashCommandType, guildId);
-                                        _logger.LogInformation($"Registered guild-specific slash commands for guild {guildId}");
+                                        _logger.LogDiscordSlashCommand(Program.DiagnosticsSettings, $"Registered guild-specific slash commands for guild {guildId}");
                                     }
                                     catch (System.Exception ex) { _logger.LogError(ex, $"Error while registering guild-specific slash commands for guild {guildId}: " + ex.Message); }
 
@@ -277,7 +277,7 @@ namespace Requestrr.WebApi.RequestrrBot
 
                             await _slashCommands.RefreshCommands();
                             registrationStopwatch.Stop();
-                            _logger.LogInformation($"Slash command registration completed in {registrationStopwatch.ElapsedMilliseconds}ms across {guildCount} guilds");
+                            _logger.LogDiscordSlashCommand(Program.DiagnosticsSettings, $"Slash command registration completed in {registrationStopwatch.ElapsedMilliseconds}ms across {guildCount} guilds");
                             await Task.Delay(TimeSpan.FromSeconds(5));
                         }
                         catch (Exception ex)
@@ -305,19 +305,19 @@ namespace Requestrr.WebApi.RequestrrBot
         {
             var guildCount = client.Guilds.Count;
             var latency = client.Ping;
-            _logger.LogInformation($"Discord bot connected to {guildCount} guilds, Latency: {latency}ms");
+            _logger.LogDiscordConnection(Program.DiagnosticsSettings, $"Discord bot connected to {guildCount} guilds, Latency: {latency}ms");
             await ApplyBotConfigurationAsync(_currentSettings);
         }
 
         private Task HeartbeatedHandler(DiscordClient client, HeartbeatEventArgs args)
         {
-            _logger.LogInformation($"Heartbeat received, Latency: {args.Ping}ms");
+            _logger.LogDiscordHeartbeat(Program.DiagnosticsSettings, args.Ping);
             return Task.CompletedTask;
         }
 
         private Task ResumedHandler(DiscordClient client, ReadyEventArgs args)
         {
-            _logger.LogInformation("Discord connection resumed");
+            _logger.LogDiscordConnection(Program.DiagnosticsSettings, "Discord connection resumed");
             return Task.CompletedTask;
         }
 

--- a/Requestrr.WebApi/RequestrrBot/ChatBot.cs
+++ b/Requestrr.WebApi/RequestrrBot/ChatBot.cs
@@ -210,36 +210,62 @@ namespace Requestrr.WebApi.RequestrrBot
                         {
                             await ApplyBotConfigurationAsync(newSettings);
 
-                            var prop = _slashCommands.GetType().GetProperty("_updateList", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-                            prop.SetValue(_slashCommands, new List<KeyValuePair<ulong?, Type>>());
-
                             var slashCommandType = SlashCommandBuilder.Build(_logger, newSettings, _serviceProvider.Get<RadarrSettingsProvider>(), _serviceProvider.Get<SonarrSettingsProvider>(), _serviceProvider.Get<OverseerrSettingsProvider>(), _serviceProvider.Get<OmbiSettingsProvider>(), _serviceProvider.Get<LidarrSettingsProvider>());
 
                             if (newSettings.EnableRequestsThroughDirectMessages)
                             {
-                                try { _slashCommands.RegisterCommands(slashCommandType); }
+                                try
+                                {
+                                    _slashCommands.RegisterCommands(slashCommandType);
+                                    _logger.LogInformation("Registered global slash commands");
+                                }
                                 catch (System.Exception ex) { _logger.LogError(ex, "Error while registering global slash commands: " + ex.Message); }
+
+                                // Add delay to prevent Discord rate limiting
+                                await Task.Delay(TimeSpan.FromSeconds(2));
 
                                 foreach (var guildId in _client.Guilds.Keys)
                                 {
-                                    try { _slashCommands.RegisterCommands<EmptySlashCommands>(guildId); }
-                                    catch (System.Exception ex) { _logger.LogError(ex, $"Error while emptying guild-specific slash commands for guid {guildId}: " + ex.Message); }
+                                    try
+                                    {
+                                        _slashCommands.RegisterCommands<EmptySlashCommands>(guildId);
+                                        _logger.LogInformation($"Emptied guild-specific slash commands for guild {guildId}");
+                                    }
+                                    catch (System.Exception ex) { _logger.LogError(ex, $"Error while emptying guild-specific slash commands for guild {guildId}: " + ex.Message); }
+
+                                    // Add delay between guild registrations to prevent rate limiting
+                                    await Task.Delay(TimeSpan.FromSeconds(1));
                                 }
                             }
                             else
                             {
-                                try { _slashCommands.RegisterCommands<EmptySlashCommands>(); }
+                                try
+                                {
+                                    _slashCommands.RegisterCommands<EmptySlashCommands>();
+                                    _logger.LogInformation("Emptied global slash commands");
+                                }
                                 catch (System.Exception ex) { _logger.LogError(ex, "Error while emptying global slash commands: " + ex.Message); }
+
+                                // Add delay to prevent Discord rate limiting
+                                await Task.Delay(TimeSpan.FromSeconds(2));
 
                                 foreach (var guildId in _client.Guilds.Keys)
                                 {
-                                    try { _slashCommands.RegisterCommands(slashCommandType, guildId); }
-                                    catch (System.Exception ex) { _logger.LogError(ex, $"Error while registering guild-specific slash commands for guid {guildId}: " + ex.Message); }
+                                    try
+                                    {
+                                        _slashCommands.RegisterCommands(slashCommandType, guildId);
+                                        _logger.LogInformation($"Registered guild-specific slash commands for guild {guildId}");
+                                    }
+                                    catch (System.Exception ex) { _logger.LogError(ex, $"Error while registering guild-specific slash commands for guild {guildId}: " + ex.Message); }
+
+                                    // Add delay between guild registrations to prevent rate limiting
+                                    await Task.Delay(TimeSpan.FromSeconds(1));
                                 }
                             }
 
                             await _slashCommands.RefreshCommands();
-                            await Task.Delay(TimeSpan.FromMinutes(1));
+                            _logger.LogInformation("Slash commands refresh completed");
+                            await Task.Delay(TimeSpan.FromSeconds(5));
                         }
                         catch (Exception ex)
                         {

--- a/Requestrr.WebApi/RequestrrBot/ChatBot.cs
+++ b/Requestrr.WebApi/RequestrrBot/ChatBot.cs
@@ -27,6 +27,8 @@ using Requestrr.WebApi.RequestrrBot.Notifications.Movies;
 using Requestrr.WebApi.RequestrrBot.Notifications.Music;
 using Requestrr.WebApi.RequestrrBot.Notifications.TvShows;
 using Requestrr.WebApi.RequestrrBot.TvShows;
+using Requestrr.WebApi.RequestrrBot.Logging;
+using System.Diagnostics;
 
 namespace Requestrr.WebApi.RequestrrBot
 {
@@ -67,9 +69,9 @@ namespace Requestrr.WebApi.RequestrrBot
             _radarrDownloadClient = new RadarrClient(serviceProvider.Get<IHttpClientFactory>(), serviceProvider.Get<ILogger<RadarrClient>>(), serviceProvider.Get<RadarrSettingsProvider>());
             _sonarrDownloadClient = new SonarrClient(serviceProvider.Get<IHttpClientFactory>(), serviceProvider.Get<ILogger<SonarrClient>>(), serviceProvider.Get<SonarrSettingsProvider>());
             _lidarrDownloadClient = new LidarrClient(serviceProvider.Get<IHttpClientFactory>(), serviceProvider.Get<ILogger<LidarrClient>>(), serviceProvider.Get<LidarrSettingsProvider>());
-            _movieWorkflowFactory = new MovieWorkflowFactory(_discordSettingsProvider, _movieNotificationRepository, _overseerrClient, _ombiDownloadClient, _radarrDownloadClient);
-            _tvShowWorkflowFactory = new TvShowWorkflowFactory(serviceProvider.Get<TvShowsSettingsProvider>(), _discordSettingsProvider, _tvShowNotificationRepository, _overseerrClient, _ombiDownloadClient, _sonarrDownloadClient);
-            _musicWorkflowFactory = new MusicWorkflowFactory(_discordSettingsProvider, _musicNotificationRepository, _lidarrDownloadClient);
+            _movieWorkflowFactory = new MovieWorkflowFactory(_discordSettingsProvider, _movieNotificationRepository, _overseerrClient, _ombiDownloadClient, _radarrDownloadClient, _logger);
+            _tvShowWorkflowFactory = new TvShowWorkflowFactory(serviceProvider.Get<TvShowsSettingsProvider>(), _discordSettingsProvider, _tvShowNotificationRepository, _overseerrClient, _ombiDownloadClient, _sonarrDownloadClient, _logger);
+            _musicWorkflowFactory = new MusicWorkflowFactory(_discordSettingsProvider, _musicNotificationRepository, _lidarrDownloadClient, _logger);
         }
 
         public async void Start()
@@ -183,6 +185,9 @@ namespace Requestrr.WebApi.RequestrrBot
                     _client.Ready += Connected;
                     _client.ComponentInteractionCreated += DiscordComponentInteractionCreatedHandler;
                     _client.ModalSubmitted += DiscordModalSubmittedHandler;
+                    _client.Heartbeated += HeartbeatedHandler;
+                    _client.Resumed += ResumedHandler;
+                    _client.SocketErrored += SocketErroredHandler;
 
                     _currentGuilds = new HashSet<ulong>();
 
@@ -214,6 +219,10 @@ namespace Requestrr.WebApi.RequestrrBot
                             prop.SetValue(_slashCommands, new List<KeyValuePair<ulong?, Type>>());
 
                             var slashCommandType = SlashCommandBuilder.Build(_logger, newSettings, _serviceProvider.Get<RadarrSettingsProvider>(), _serviceProvider.Get<SonarrSettingsProvider>(), _serviceProvider.Get<OverseerrSettingsProvider>(), _serviceProvider.Get<OmbiSettingsProvider>(), _serviceProvider.Get<LidarrSettingsProvider>());
+
+                            var guildCount = _client.Guilds.Count;
+                            _logger.LogInformation($"Starting slash command registration for {guildCount} guilds");
+                            var registrationStopwatch = Stopwatch.StartNew();
 
                             if (newSettings.EnableRequestsThroughDirectMessages)
                             {
@@ -267,7 +276,8 @@ namespace Requestrr.WebApi.RequestrrBot
                             }
 
                             await _slashCommands.RefreshCommands();
-                            _logger.LogInformation("Slash commands refresh completed");
+                            registrationStopwatch.Stop();
+                            _logger.LogInformation($"Slash command registration completed in {registrationStopwatch.ElapsedMilliseconds}ms across {guildCount} guilds");
                             await Task.Delay(TimeSpan.FromSeconds(5));
                         }
                         catch (Exception ex)
@@ -293,7 +303,28 @@ namespace Requestrr.WebApi.RequestrrBot
 
         private async Task Connected(DiscordClient client, ReadyEventArgs args)
         {
+            var guildCount = client.Guilds.Count;
+            var latency = client.Ping;
+            _logger.LogInformation($"Discord bot connected to {guildCount} guilds, Latency: {latency}ms");
             await ApplyBotConfigurationAsync(_currentSettings);
+        }
+
+        private Task HeartbeatedHandler(DiscordClient client, HeartbeatEventArgs args)
+        {
+            _logger.LogInformation($"Heartbeat received, Latency: {args.Ping}ms");
+            return Task.CompletedTask;
+        }
+
+        private Task ResumedHandler(DiscordClient client, ReadyEventArgs args)
+        {
+            _logger.LogInformation("Discord connection resumed");
+            return Task.CompletedTask;
+        }
+
+        private Task SocketErroredHandler(DiscordClient client, SocketErrorEventArgs args)
+        {
+            _logger.LogWarning(args.Exception, $"WebSocket error: {args.Exception.Message}");
+            return Task.CompletedTask;
         }
 
         private async Task ApplyBotConfigurationAsync(DiscordSettings discordSettings)

--- a/Requestrr.WebApi/RequestrrBot/ChatBot.cs
+++ b/Requestrr.WebApi/RequestrrBot/ChatBot.cs
@@ -210,6 +210,9 @@ namespace Requestrr.WebApi.RequestrrBot
                         {
                             await ApplyBotConfigurationAsync(newSettings);
 
+                            var prop = _slashCommands.GetType().GetProperty("_updateList", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                            prop.SetValue(_slashCommands, new List<KeyValuePair<ulong?, Type>>());
+
                             var slashCommandType = SlashCommandBuilder.Build(_logger, newSettings, _serviceProvider.Get<RadarrSettingsProvider>(), _serviceProvider.Get<SonarrSettingsProvider>(), _serviceProvider.Get<OverseerrSettingsProvider>(), _serviceProvider.Get<OmbiSettingsProvider>(), _serviceProvider.Get<LidarrSettingsProvider>());
 
                             if (newSettings.EnableRequestsThroughDirectMessages)

--- a/Requestrr.WebApi/RequestrrBot/DownloadClients/Lidarr/LidarrClientV1.cs
+++ b/Requestrr.WebApi/RequestrrBot/DownloadClients/Lidarr/LidarrClientV1.cs
@@ -2,9 +2,11 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Requestrr.WebApi.Extensions;
+using Requestrr.WebApi.RequestrrBot.Logging;
 using Requestrr.WebApi.RequestrrBot.Music;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -197,9 +199,13 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Lidarr
         /// </summary>
         /// <param name="url"></param>
         /// <returns></returns>
-        private Task<HttpResponseMessage> HttpGetAsync(string url)
+        private async Task<HttpResponseMessage> HttpGetAsync(string url)
         {
-            return HttpGetAsync(_httpClientFactory.CreateClient(), _lidarrSettings, url);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await HttpGetAsync(_httpClientFactory.CreateClient(), _lidarrSettings, url);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Lidarr", "GET", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
 
@@ -472,7 +478,11 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Lidarr
             postRequest.Headers.Add("X-Api-Key", _lidarrSettings.ApiKey);
 
             HttpClient client = _httpClientFactory.CreateClient();
-            return await client.PostAsync(url, postRequest);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await client.PostAsync(url, postRequest);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Lidarr", "POST", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
 
@@ -484,7 +494,11 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Lidarr
             postRequest.Headers.Add("X-Api-Key", _lidarrSettings.ApiKey);
 
             HttpClient client = _httpClientFactory.CreateClient();
-            return await client.PutAsync(url, postRequest);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await client.PutAsync(url, postRequest);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Lidarr", "PUT", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
 

--- a/Requestrr.WebApi/RequestrrBot/DownloadClients/Ombi/OmbiClient.cs
+++ b/Requestrr.WebApi/RequestrrBot/DownloadClients/Ombi/OmbiClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -9,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Requestrr.WebApi.Extensions;
+using Requestrr.WebApi.RequestrrBot.Logging;
 using Requestrr.WebApi.RequestrrBot.Movies;
 using Requestrr.WebApi.RequestrrBot.TvShows;
 using static Requestrr.WebApi.RequestrrBot.DownloadClients.Ombi.OmbiClient;
@@ -611,9 +613,13 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Ombi
             return $"{protocol}://{settings.Hostname}:{settings.Port}{settings.BaseUrl}";
         }
 
-        private Task<HttpResponseMessage> HttpGetAsync(string url)
+        private async Task<HttpResponseMessage> HttpGetAsync(string url)
         {
-            return HttpGetAsync(_httpClientFactory.CreateClient(), OmbiSettings, url);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await HttpGetAsync(_httpClientFactory.CreateClient(), OmbiSettings, url);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Ombi", "GET", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private static async Task<HttpResponseMessage> HttpGetAsync(HttpClient client, OmbiSettings settings, string url)
@@ -642,7 +648,11 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Ombi
             }
 
             var client = _httpClientFactory.CreateClient();
-            return await client.PostAsync(url, postRequest);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await client.PostAsync(url, postRequest);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Ombi", "POST", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private string Sanitize(string value)

--- a/Requestrr.WebApi/RequestrrBot/DownloadClients/Overseerr/OverseerrClient.cs
+++ b/Requestrr.WebApi/RequestrrBot/DownloadClients/Overseerr/OverseerrClient.cs
@@ -1056,7 +1056,7 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Overseerr
             var stopwatch = Stopwatch.StartNew();
             var response = await client.PostAsync(url, postRequest);
             stopwatch.Stop();
-            _logger.LogHttpRequest("Overseerr", "POST", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Overseerr", "POST", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
             return response;
         }
 
@@ -1066,7 +1066,7 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Overseerr
             var stopwatch = Stopwatch.StartNew();
             var response = await HttpGetAsync(client, OverseerrSettings, url);
             stopwatch.Stop();
-            _logger.LogHttpRequest("Overseerr", "GET", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Overseerr", "GET", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
             return response;
         }
 
@@ -1086,7 +1086,7 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Overseerr
             var stopwatch = Stopwatch.StartNew();
             var response = await client.PutAsync(url, postRequest);
             stopwatch.Stop();
-            _logger.LogHttpRequest("Overseerr", "PUT", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Overseerr", "PUT", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
             return response;
         }
 

--- a/Requestrr.WebApi/RequestrrBot/DownloadClients/Overseerr/OverseerrClient.cs
+++ b/Requestrr.WebApi/RequestrrBot/DownloadClients/Overseerr/OverseerrClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -11,6 +12,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Requestrr.WebApi.Extensions;
 using Requestrr.WebApi.RequestrrBot.Locale;
+using Requestrr.WebApi.RequestrrBot.Logging;
 using Requestrr.WebApi.RequestrrBot.Movies;
 using Requestrr.WebApi.RequestrrBot.TvShows;
 
@@ -1051,7 +1053,21 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Overseerr
             }
 
             var client = _httpClientFactory.CreateClient();
-            return await client.PostAsync(url, postRequest);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await client.PostAsync(url, postRequest);
+            stopwatch.Stop();
+            _logger.LogHttpRequest("Overseerr", "POST", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
+        }
+
+        private async Task<HttpResponseMessage> LoggedHttpGetAsync(string url)
+        {
+            var client = _httpClientFactory.CreateClient();
+            var stopwatch = Stopwatch.StartNew();
+            var response = await HttpGetAsync(client, OverseerrSettings, url);
+            stopwatch.Stop();
+            _logger.LogHttpRequest("Overseerr", "GET", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private async Task<HttpResponseMessage> HttpPutAsync(string overseerrUserId, string url, string content)
@@ -1067,7 +1083,11 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Overseerr
             }
 
             var client = _httpClientFactory.CreateClient();
-            return await client.PutAsync(url, postRequest);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await client.PutAsync(url, postRequest);
+            stopwatch.Stop();
+            _logger.LogHttpRequest("Overseerr", "PUT", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private static string GetBaseURL(OverseerrTestSettings settings)

--- a/Requestrr.WebApi/RequestrrBot/DownloadClients/Radarr/RadarrClientV2.cs
+++ b/Requestrr.WebApi/RequestrrBot/DownloadClients/Radarr/RadarrClientV2.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -8,7 +9,9 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Requestrr.WebApi.config;
 using Requestrr.WebApi.Extensions;
+using Requestrr.WebApi.RequestrrBot.Logging;
 using Requestrr.WebApi.RequestrrBot.Movies;
 using static Requestrr.WebApi.RequestrrBot.DownloadClients.Radarr.RadarrClient;
 
@@ -396,9 +399,13 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Radarr
             return JsonConvert.DeserializeObject<JSONMovie>(jsonResponse);
         }
 
-        private Task<HttpResponseMessage> HttpGetAsync(string url)
+        private async Task<HttpResponseMessage> HttpGetAsync(string url)
         {
-            return HttpGetAsync(_httpClientFactory.CreateClient(), RadarrSettings, url);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await HttpGetAsync(_httpClientFactory.CreateClient(), RadarrSettings, url);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Radarr", "GET", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private static async Task<HttpResponseMessage> HttpGetAsync(HttpClient client, RadarrSettings settings, string url)
@@ -421,7 +428,11 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Radarr
             postRequest.Headers.Add("X-Api-Key", RadarrSettings.ApiKey);
 
             var client = _httpClientFactory.CreateClient();
-            return await client.PostAsync(url, postRequest);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await client.PostAsync(url, postRequest);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Radarr", "POST", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private async Task<HttpResponseMessage> HttpPutAsync(string url, string content)
@@ -432,7 +443,11 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Radarr
             putRequest.Headers.Add("X-Api-Key", RadarrSettings.ApiKey);
 
             var client = _httpClientFactory.CreateClient();
-            return await client.PutAsync(url, putRequest);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await client.PutAsync(url, putRequest);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Radarr", "PUT", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private static string GetBaseURL(RadarrSettings settings)

--- a/Requestrr.WebApi/RequestrrBot/DownloadClients/Radarr/RadarrClientV3.cs
+++ b/Requestrr.WebApi/RequestrrBot/DownloadClients/Radarr/RadarrClientV3.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -8,7 +9,9 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Requestrr.WebApi.config;
 using Requestrr.WebApi.Extensions;
+using Requestrr.WebApi.RequestrrBot.Logging;
 using Requestrr.WebApi.RequestrrBot.Movies;
 using static Requestrr.WebApi.RequestrrBot.DownloadClients.Radarr.RadarrClient;
 
@@ -413,9 +416,13 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Radarr
             return JsonConvert.DeserializeObject<JSONMovie>(jsonResponse);
         }
 
-        private Task<HttpResponseMessage> HttpGetAsync(string url)
+        private async Task<HttpResponseMessage> HttpGetAsync(string url)
         {
-            return HttpGetAsync(_httpClientFactory.CreateClient(), RadarrSettings, url);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await HttpGetAsync(_httpClientFactory.CreateClient(), RadarrSettings, url);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Radarr", "GET", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private static async Task<HttpResponseMessage> HttpGetAsync(HttpClient client, RadarrSettings settings, string url)
@@ -438,7 +445,11 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Radarr
             postRequest.Headers.Add("X-Api-Key", RadarrSettings.ApiKey);
 
             var client = _httpClientFactory.CreateClient();
-            return await client.PostAsync(url, postRequest);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await client.PostAsync(url, postRequest);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Radarr", "POST", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private async Task<HttpResponseMessage> HttpPutAsync(string url, string content)
@@ -449,7 +460,11 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Radarr
             putRequest.Headers.Add("X-Api-Key", RadarrSettings.ApiKey);
 
             var client = _httpClientFactory.CreateClient();
-            return await client.PutAsync(url, putRequest);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await client.PutAsync(url, putRequest);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Radarr", "PUT", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private static string GetBaseURL(RadarrSettings settings)

--- a/Requestrr.WebApi/RequestrrBot/DownloadClients/Sonarr/SonarrClientV2.cs
+++ b/Requestrr.WebApi/RequestrrBot/DownloadClients/Sonarr/SonarrClientV2.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -8,7 +9,9 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Requestrr.WebApi.config;
 using Requestrr.WebApi.Extensions;
+using Requestrr.WebApi.RequestrrBot.Logging;
 using Requestrr.WebApi.RequestrrBot.TvShows;
 using static Requestrr.WebApi.RequestrrBot.DownloadClients.Sonarr.SonarrClient;
 
@@ -664,9 +667,13 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Sonarr
             return $"{protocol}://{settings.Hostname}:{settings.Port}{settings.BaseUrl}/api";
         }
 
-        private Task<HttpResponseMessage> HttpGetAsync(string url)
+        private async Task<HttpResponseMessage> HttpGetAsync(string url)
         {
-            return HttpGetAsync(_httpClientFactory.CreateClient(), SonarrSettings, url);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await HttpGetAsync(_httpClientFactory.CreateClient(), SonarrSettings, url);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Sonarr", "GET", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private static async Task<HttpResponseMessage> HttpGetAsync(HttpClient client, SonarrSettings settings, string url)
@@ -689,7 +696,11 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Sonarr
             postRequest.Headers.Add("X-Api-Key", SonarrSettings.ApiKey);
 
             var client = _httpClientFactory.CreateClient();
-            return await client.PostAsync(url, postRequest);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await client.PostAsync(url, postRequest);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Sonarr", "POST", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private async Task<HttpResponseMessage> HttpPutAsync(string url, string content)
@@ -700,7 +711,11 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Sonarr
             putRequest.Headers.Add("X-Api-Key", SonarrSettings.ApiKey);
 
             var client = _httpClientFactory.CreateClient();
-            return await client.PutAsync(url, putRequest);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await client.PutAsync(url, putRequest);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Sonarr", "PUT", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         public class JSONEpisode

--- a/Requestrr.WebApi/RequestrrBot/DownloadClients/Sonarr/SonarrClientV3.cs
+++ b/Requestrr.WebApi/RequestrrBot/DownloadClients/Sonarr/SonarrClientV3.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -8,7 +9,9 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Requestrr.WebApi.config;
 using Requestrr.WebApi.Extensions;
+using Requestrr.WebApi.RequestrrBot.Logging;
 using Requestrr.WebApi.RequestrrBot.TvShows;
 using static Requestrr.WebApi.RequestrrBot.DownloadClients.Sonarr.SonarrClient;
 
@@ -628,9 +631,13 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Sonarr
             return $"{protocol}://{settings.Hostname}:{settings.Port}{settings.BaseUrl}/api/v{settings.Version}";
         }
 
-        private Task<HttpResponseMessage> HttpGetAsync(string url)
+        private async Task<HttpResponseMessage> HttpGetAsync(string url)
         {
-            return HttpGetAsync(_httpClientFactory.CreateClient(), SonarrSettings, url);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await HttpGetAsync(_httpClientFactory.CreateClient(), SonarrSettings, url);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Sonarr", "GET", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private static async Task<HttpResponseMessage> HttpGetAsync(HttpClient client, SonarrSettings settings, string url)
@@ -653,7 +660,11 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Sonarr
             postRequest.Headers.Add("X-Api-Key", SonarrSettings.ApiKey);
 
             var client = _httpClientFactory.CreateClient();
-            return await client.PostAsync(url, postRequest);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await client.PostAsync(url, postRequest);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Sonarr", "POST", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private async Task<HttpResponseMessage> HttpPutAsync(string url, string content)
@@ -664,7 +675,11 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Sonarr
             putRequest.Headers.Add("X-Api-Key", SonarrSettings.ApiKey);
 
             var client = _httpClientFactory.CreateClient();
-            return await client.PutAsync(url, putRequest);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await client.PutAsync(url, putRequest);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Sonarr", "PUT", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private class JSONEpisode

--- a/Requestrr.WebApi/RequestrrBot/DownloadClients/Sonarr/SonarrClientV4.cs
+++ b/Requestrr.WebApi/RequestrrBot/DownloadClients/Sonarr/SonarrClientV4.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -8,7 +9,9 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Requestrr.WebApi.config;
 using Requestrr.WebApi.Extensions;
+using Requestrr.WebApi.RequestrrBot.Logging;
 using Requestrr.WebApi.RequestrrBot.TvShows;
 using static Requestrr.WebApi.RequestrrBot.DownloadClients.Sonarr.SonarrClient;
 
@@ -626,9 +629,13 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Sonarr
             return $"{protocol}://{settings.Hostname}:{settings.Port}{settings.BaseUrl}/api/v3";
         }
 
-        private Task<HttpResponseMessage> HttpGetAsync(string url)
+        private async Task<HttpResponseMessage> HttpGetAsync(string url)
         {
-            return HttpGetAsync(_httpClientFactory.CreateClient(), SonarrSettings, url);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await HttpGetAsync(_httpClientFactory.CreateClient(), SonarrSettings, url);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Sonarr", "GET", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private static async Task<HttpResponseMessage> HttpGetAsync(HttpClient client, SonarrSettings settings, string url)
@@ -651,7 +658,11 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Sonarr
             postRequest.Headers.Add("X-Api-Key", SonarrSettings.ApiKey);
 
             var client = _httpClientFactory.CreateClient();
-            return await client.PostAsync(url, postRequest);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await client.PostAsync(url, postRequest);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Sonarr", "POST", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private async Task<HttpResponseMessage> HttpPutAsync(string url, string content)
@@ -662,7 +673,11 @@ namespace Requestrr.WebApi.RequestrrBot.DownloadClients.Sonarr
             putRequest.Headers.Add("X-Api-Key", SonarrSettings.ApiKey);
 
             var client = _httpClientFactory.CreateClient();
-            return await client.PutAsync(url, putRequest);
+            var stopwatch = Stopwatch.StartNew();
+            var response = await client.PutAsync(url, putRequest);
+            stopwatch.Stop();
+            _logger.LogHttpRequest(Program.DiagnosticsSettings, "Sonarr", "PUT", url, response.StatusCode, stopwatch.ElapsedMilliseconds);
+            return response;
         }
 
         private class JSONEpisode

--- a/Requestrr.WebApi/RequestrrBot/Logging/LoggingExtensions.cs
+++ b/Requestrr.WebApi/RequestrrBot/Logging/LoggingExtensions.cs
@@ -1,19 +1,26 @@
 using System;
 using System.Net;
 using Microsoft.Extensions.Logging;
+using Requestrr.WebApi.config;
 
 namespace Requestrr.WebApi.RequestrrBot.Logging
 {
     public static class LoggingExtensions
     {
-        public static void LogHttpRequest(this ILogger logger, string clientType, string method, string endpoint, HttpStatusCode statusCode, long milliseconds)
+        public static void LogHttpRequest(this ILogger logger, DiagnosticsSettings diagnostics, string clientType, string method, string endpoint, HttpStatusCode statusCode, long milliseconds)
         {
-            logger.LogInformation($"{clientType} API: {method} {endpoint} - {(int)statusCode} {statusCode} in {milliseconds}ms");
+            if (diagnostics?.ShouldLogHttpFor(clientType) == true)
+            {
+                logger.LogInformation($"{clientType} API: {method} {endpoint} - {(int)statusCode} {statusCode} in {milliseconds}ms");
+            }
         }
 
-        public static void LogHttpRequest(this ILogger logger, string clientType, string method, string endpoint, int statusCode, long milliseconds)
+        public static void LogHttpRequest(this ILogger logger, DiagnosticsSettings diagnostics, string clientType, string method, string endpoint, int statusCode, long milliseconds)
         {
-            logger.LogInformation($"{clientType} API: {method} {endpoint} - {statusCode} in {milliseconds}ms");
+            if (diagnostics?.ShouldLogHttpFor(clientType) == true)
+            {
+                logger.LogInformation($"{clientType} API: {method} {endpoint} - {statusCode} in {milliseconds}ms");
+            }
         }
 
         public static void LogHttpError(this ILogger logger, string clientType, string endpoint, Exception ex, int attemptNumber = 1)
@@ -45,19 +52,49 @@ namespace Requestrr.WebApi.RequestrrBot.Logging
             }
         }
 
-        public static void LogNotificationCycle(this ILogger logger, string notificationType, int checkedCount, int availableCount, int sentCount, long milliseconds)
+        public static void LogNotificationCycle(this ILogger logger, DiagnosticsSettings diagnostics, string notificationType, int checkedCount, int availableCount, int sentCount, long milliseconds)
         {
-            logger.LogInformation($"{notificationType} notification cycle: Checked {checkedCount}, Available {availableCount}, Sent {sentCount} in {milliseconds}ms");
+            if (diagnostics?.ShouldLogNotificationCycle(notificationType) == true)
+            {
+                logger.LogInformation($"{notificationType} notification cycle: Checked {checkedCount}, Available {availableCount}, Sent {sentCount} in {milliseconds}ms");
+            }
         }
 
-        public static void LogNotificationStart(this ILogger logger, string notificationType, int pendingCount)
+        public static void LogNotificationStart(this ILogger logger, DiagnosticsSettings diagnostics, string notificationType, int pendingCount)
         {
-            logger.LogInformation($"{notificationType} notification cycle started, checking {pendingCount} pending notifications");
+            if (diagnostics?.ShouldLogNotificationCycle(notificationType) == true)
+            {
+                logger.LogInformation($"{notificationType} notification cycle started, checking {pendingCount} pending notifications");
+            }
         }
 
         public static void LogNotificationDelivered(this ILogger logger, string notificationType, string userId, string itemTitle)
         {
             logger.LogInformation($"{notificationType} notification sent: User {userId} notified for '{itemTitle}'");
+        }
+
+        public static void LogDiscordHeartbeat(this ILogger logger, DiagnosticsSettings diagnostics, int latency)
+        {
+            if (diagnostics?.ShouldLogDiscordHeartbeat() == true)
+            {
+                logger.LogInformation($"Heartbeat received, Latency: {latency}ms");
+            }
+        }
+
+        public static void LogDiscordSlashCommand(this ILogger logger, DiagnosticsSettings diagnostics, string message)
+        {
+            if (diagnostics?.ShouldLogDiscordSlashCommands() == true)
+            {
+                logger.LogInformation(message);
+            }
+        }
+
+        public static void LogDiscordConnection(this ILogger logger, DiagnosticsSettings diagnostics, string message)
+        {
+            if (diagnostics?.ShouldLogDiscordConnections() == true)
+            {
+                logger.LogInformation(message);
+            }
         }
     }
 }

--- a/Requestrr.WebApi/RequestrrBot/Logging/LoggingExtensions.cs
+++ b/Requestrr.WebApi/RequestrrBot/Logging/LoggingExtensions.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Net;
+using Microsoft.Extensions.Logging;
+
+namespace Requestrr.WebApi.RequestrrBot.Logging
+{
+    public static class LoggingExtensions
+    {
+        public static void LogHttpRequest(this ILogger logger, string clientType, string method, string endpoint, HttpStatusCode statusCode, long milliseconds)
+        {
+            logger.LogInformation($"{clientType} API: {method} {endpoint} - {(int)statusCode} {statusCode} in {milliseconds}ms");
+        }
+
+        public static void LogHttpRequest(this ILogger logger, string clientType, string method, string endpoint, int statusCode, long milliseconds)
+        {
+            logger.LogInformation($"{clientType} API: {method} {endpoint} - {statusCode} in {milliseconds}ms");
+        }
+
+        public static void LogHttpError(this ILogger logger, string clientType, string endpoint, Exception ex, int attemptNumber = 1)
+        {
+            if (attemptNumber > 1)
+            {
+                logger.LogWarning(ex, $"{clientType} API request to {endpoint} failed (attempt {attemptNumber}): {ex.Message}");
+            }
+            else
+            {
+                logger.LogError(ex, $"{clientType} API request to {endpoint} failed: {ex.Message}");
+            }
+        }
+
+        public static void LogWorkflowStart(this ILogger logger, string workflowType, string userId, string itemName)
+        {
+            logger.LogInformation($"{workflowType} workflow started: User {userId} searching for '{itemName}'");
+        }
+
+        public static void LogWorkflowComplete(this ILogger logger, string workflowType, long milliseconds, int? resultCount = null)
+        {
+            if (resultCount.HasValue)
+            {
+                logger.LogInformation($"{workflowType} workflow completed in {milliseconds}ms, found {resultCount} results");
+            }
+            else
+            {
+                logger.LogInformation($"{workflowType} workflow completed in {milliseconds}ms");
+            }
+        }
+
+        public static void LogNotificationCycle(this ILogger logger, string notificationType, int checkedCount, int availableCount, int sentCount, long milliseconds)
+        {
+            logger.LogInformation($"{notificationType} notification cycle: Checked {checkedCount}, Available {availableCount}, Sent {sentCount} in {milliseconds}ms");
+        }
+
+        public static void LogNotificationStart(this ILogger logger, string notificationType, int pendingCount)
+        {
+            logger.LogInformation($"{notificationType} notification cycle started, checking {pendingCount} pending notifications");
+        }
+
+        public static void LogNotificationDelivered(this ILogger logger, string notificationType, string userId, string itemTitle)
+        {
+            logger.LogInformation($"{notificationType} notification sent: User {userId} notified for '{itemTitle}'");
+        }
+    }
+}

--- a/Requestrr.WebApi/RequestrrBot/Logging/PerformanceTimer.cs
+++ b/Requestrr.WebApi/RequestrrBot/Logging/PerformanceTimer.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Requestrr.WebApi.RequestrrBot.Logging
+{
+    public class PerformanceTimer : IDisposable
+    {
+        private readonly ILogger _logger;
+        private readonly string _operationName;
+        private readonly Stopwatch _stopwatch;
+        private readonly LogLevel _logLevel;
+
+        public PerformanceTimer(ILogger logger, string operationName, LogLevel logLevel = LogLevel.Information)
+        {
+            _logger = logger;
+            _operationName = operationName;
+            _logLevel = logLevel;
+            _stopwatch = Stopwatch.StartNew();
+        }
+
+        public void Dispose()
+        {
+            _stopwatch.Stop();
+            _logger.Log(_logLevel, $"{_operationName} completed in {_stopwatch.ElapsedMilliseconds}ms");
+        }
+
+        public long ElapsedMilliseconds => _stopwatch.ElapsedMilliseconds;
+    }
+}

--- a/Requestrr.WebApi/RequestrrBot/Movies/MovieRequestingWorkflow.cs
+++ b/Requestrr.WebApi/RequestrrBot/Movies/MovieRequestingWorkflow.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Requestrr.WebApi.RequestrrBot.Logging;
 
 namespace Requestrr.WebApi.RequestrrBot.Movies
 {
@@ -13,6 +16,7 @@ namespace Requestrr.WebApi.RequestrrBot.Movies
         private readonly IMovieRequester _requester;
         private readonly IMovieUserInterface _userInterface;
         private readonly IMovieNotificationWorkflow _notificationWorkflow;
+        private readonly ILogger _logger;
 
         public MovieRequestingWorkflow(
             MovieUserRequester user,
@@ -20,7 +24,8 @@ namespace Requestrr.WebApi.RequestrrBot.Movies
             IMovieSearcher searcher,
             IMovieRequester requester,
             IMovieUserInterface userInterface,
-            IMovieNotificationWorkflow movieNotificationWorkflow)
+            IMovieNotificationWorkflow movieNotificationWorkflow,
+            ILogger logger)
         {
             _categoryId = categoryId;
             _user = user;
@@ -28,6 +33,7 @@ namespace Requestrr.WebApi.RequestrrBot.Movies
             _requester = requester;
             _userInterface = userInterface;
             _notificationWorkflow = movieNotificationWorkflow;
+            _logger = logger;
         }
 
         public async Task SearchMovieAsync(string movieName)
@@ -68,11 +74,20 @@ namespace Requestrr.WebApi.RequestrrBot.Movies
             IReadOnlyList<Movie> movies = Array.Empty<Movie>();
 
             movieName = movieName.Replace(".", " ");
+            _logger.LogWorkflowStart("Movie", _user.UserId, movieName);
+
+            var stopwatch = Stopwatch.StartNew();
             movies = await _searcher.SearchMovieAsync(new MovieRequest(_user, _categoryId), movieName);
+            stopwatch.Stop();
 
             if (!movies.Any())
             {
+                _logger.LogInformation($"Movie search completed in {stopwatch.ElapsedMilliseconds}ms, found 0 results for '{movieName}'");
                 await _userInterface.WarnNoMovieFoundAsync(movieName);
+            }
+            else
+            {
+                _logger.LogWorkflowComplete("Movie search", stopwatch.ElapsedMilliseconds, movies.Count);
             }
 
             return movies;
@@ -107,14 +122,20 @@ namespace Requestrr.WebApi.RequestrrBot.Movies
         public async Task RequestMovieAsync(int theMovieDbId)
         {
             var movie = await _searcher.SearchMovieAsync(new MovieRequest(_user, _categoryId), theMovieDbId);
+
+            _logger.LogInformation($"User {_user.UserId} requesting movie: '{movie.Title}' (TMDB: {theMovieDbId})");
+            var stopwatch = Stopwatch.StartNew();
             var result = await _requester.RequestMovieAsync(new MovieRequest(_user, _categoryId), movie);
+            stopwatch.Stop();
 
             if (result.WasDenied)
             {
+                _logger.LogWarning($"Movie request denied for '{movie.Title}' in {stopwatch.ElapsedMilliseconds}ms");
                 await _userInterface.DisplayRequestDeniedAsync(movie);
             }
             else
             {
+                _logger.LogInformation($"Movie request submitted successfully for '{movie.Title}' in {stopwatch.ElapsedMilliseconds}ms");
                 await _userInterface.DisplayRequestSuccessAsync(movie);
                 await _notificationWorkflow.NotifyForNewRequestAsync(_user.UserId, movie);
             }

--- a/Requestrr.WebApi/RequestrrBot/Movies/MovieWorkflowFactory.cs
+++ b/Requestrr.WebApi/RequestrrBot/Movies/MovieWorkflowFactory.cs
@@ -21,19 +21,22 @@ namespace Requestrr.WebApi.RequestrrBot.Movies
         private OverseerrClient _overseerrClient;
         private OmbiClient _ombiDownloadClient;
         private RadarrClient _radarrDownloadClient;
+        private readonly ILogger _logger;
 
         public MovieWorkflowFactory(
             DiscordSettingsProvider settingsProvider,
             MovieNotificationsRepository notificationsRepository,
             OverseerrClient overseerrClient,
             OmbiClient ombiDownloadClient,
-            RadarrClient radarrDownloadClient)
+            RadarrClient radarrDownloadClient,
+            ILogger logger)
         {
             _settingsProvider = settingsProvider;
             _notificationsRepository = notificationsRepository;
             _overseerrClient = overseerrClient;
             _ombiDownloadClient = ombiDownloadClient;
             _radarrDownloadClient = radarrDownloadClient;
+            _logger = logger;
         }
 
         public MovieRequestingWorkflow CreateRequestingWorkflow(DiscordInteraction interaction, int categoryId)
@@ -45,7 +48,8 @@ namespace Requestrr.WebApi.RequestrrBot.Movies
                                                 GetMovieClient<IMovieSearcher>(settings),
                                                 GetMovieClient<IMovieRequester>(settings),
                                                 new DiscordMovieUserInterface(interaction, GetMovieClient<IMovieSearcher>(settings)),
-                                                CreateMovieNotificationWorkflow(interaction, settings));
+                                                CreateMovieNotificationWorkflow(interaction, settings),
+                                                _logger);
         }
 
 

--- a/Requestrr.WebApi/RequestrrBot/Music/MusicWorkflowFactory.cs
+++ b/Requestrr.WebApi/RequestrrBot/Music/MusicWorkflowFactory.cs
@@ -16,17 +16,19 @@ namespace Requestrr.WebApi.RequestrrBot.Music
         private readonly DiscordSettingsProvider _settingsProvider;
         private readonly MusicNotificationsRepository _notificationsRepository;
         private LidarrClient _lidarrClient;
-
+        private readonly ILogger _logger;
 
         public MusicWorkflowFactory(
             DiscordSettingsProvider settingsProvider,
             MusicNotificationsRepository musicNotificationsRepository,
-            LidarrClient lidarrClient
+            LidarrClient lidarrClient,
+            ILogger logger
         )
         {
             _settingsProvider = settingsProvider;
             _notificationsRepository = musicNotificationsRepository;
             _lidarrClient = lidarrClient;
+            _logger = logger;
         }
 
 

--- a/Requestrr.WebApi/RequestrrBot/Notifications/Movies/ChannelMovieNotifier.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/Movies/ChannelMovieNotifier.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Requestrr.WebApi/RequestrrBot/Notifications/Movies/ChannelMovieNotifier.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/Movies/ChannelMovieNotifier.cs
@@ -46,6 +46,9 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.Movies
                     try
                     {
                         await NotifyUsersInChannel(movie, discordUserIds, userNotified, channel);
+
+                        // Add delay to prevent Discord rate limiting
+                        await Task.Delay(TimeSpan.FromSeconds(1));
                     }
                     catch (System.Exception ex)
                     {

--- a/Requestrr.WebApi/RequestrrBot/Notifications/Movies/MovieNotificationEngine.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/Movies/MovieNotificationEngine.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Requestrr.WebApi.RequestrrBot.Logging;
 using Requestrr.WebApi.RequestrrBot.Movies;
 
 namespace Requestrr.WebApi.RequestrrBot.Notifications.Movies
@@ -38,9 +40,14 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.Movies
                 while (!_tokenSource.IsCancellationRequested)
                 {
                     var currentRequests = new Dictionary<int, HashSet<string>>();
+                    var cycleStopwatch = Stopwatch.StartNew();
+                    var notifiedCount = 0;
+
                     try
                     {
                         currentRequests = _notificationRequestRepository.GetAllMovieNotifications();
+                        _logger.LogNotificationStart("Movie", currentRequests.Count);
+
                         var availableMovies = await _movieSearcher.SearchAvailableMoviesAsync(new HashSet<int>(currentRequests.Keys), _tokenSource.Token);
 
                         foreach (var request in currentRequests.Where(x => availableMovies.ContainsKey(x.Key)))
@@ -51,6 +58,7 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.Movies
                             try
                             {
                                 var userNotified = await _notifier.NotifyAsync(request.Value.ToArray(), availableMovies[request.Key], _tokenSource.Token);
+                                notifiedCount += userNotified.Length;
 
                                 foreach (var userId in userNotified)
                                 {
@@ -85,6 +93,9 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.Movies
                             }
                         }
                     }
+
+                    cycleStopwatch.Stop();
+                    _logger.LogNotificationCycle("Movie", currentRequests.Count, currentRequests.Count, notifiedCount, cycleStopwatch.ElapsedMilliseconds);
 
                     await Task.Delay(TimeSpan.FromMinutes(1), _tokenSource.Token);
                 }

--- a/Requestrr.WebApi/RequestrrBot/Notifications/Movies/MovieNotificationEngine.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/Movies/MovieNotificationEngine.cs
@@ -46,7 +46,7 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.Movies
                     try
                     {
                         currentRequests = _notificationRequestRepository.GetAllMovieNotifications();
-                        _logger.LogNotificationStart("Movie", currentRequests.Count);
+                        _logger.LogNotificationStart(Program.DiagnosticsSettings, "Movie", currentRequests.Count);
 
                         var availableMovies = await _movieSearcher.SearchAvailableMoviesAsync(new HashSet<int>(currentRequests.Keys), _tokenSource.Token);
 
@@ -95,7 +95,7 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.Movies
                     }
 
                     cycleStopwatch.Stop();
-                    _logger.LogNotificationCycle("Movie", currentRequests.Count, currentRequests.Count, notifiedCount, cycleStopwatch.ElapsedMilliseconds);
+                    _logger.LogNotificationCycle(Program.DiagnosticsSettings, "Movie", currentRequests.Count, currentRequests.Count, notifiedCount, cycleStopwatch.ElapsedMilliseconds);
 
                     await Task.Delay(TimeSpan.FromMinutes(1), _tokenSource.Token);
                 }

--- a/Requestrr.WebApi/RequestrrBot/Notifications/Movies/MovieNotificationEngine.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/Movies/MovieNotificationEngine.cs
@@ -58,7 +58,7 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.Movies
                             try
                             {
                                 var userNotified = await _notifier.NotifyAsync(request.Value.ToArray(), availableMovies[request.Key], _tokenSource.Token);
-                                notifiedCount += userNotified.Length;
+                                notifiedCount += userNotified.Count;
 
                                 foreach (var userId in userNotified)
                                 {

--- a/Requestrr.WebApi/RequestrrBot/Notifications/Movies/PrivateMessageMovieNotifier.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/Movies/PrivateMessageMovieNotifier.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Requestrr.WebApi/RequestrrBot/Notifications/Movies/PrivateMessageMovieNotifier.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/Movies/PrivateMessageMovieNotifier.cs
@@ -53,6 +53,9 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.Movies
                         {
                             var channel = await user.CreateDmChannelAsync();
                             await channel.SendMessageAsync(Language.Current.DiscordNotificationMovieDM.ReplaceTokens(movie), await DiscordMovieUserInterface.GenerateMovieDetailsAsync(movie));
+
+                            // Add delay to prevent Discord rate limiting
+                            await Task.Delay(TimeSpan.FromSeconds(1));
                         }
                         else
                         {

--- a/Requestrr.WebApi/RequestrrBot/Notifications/Music/ChannelMusicNotifier.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/Music/ChannelMusicNotifier.cs
@@ -49,6 +49,9 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.Music
                     try
                     {
                         await NotifyUsersInChannelForArtist(musicArtist, discordUserIds, userNotified, channel);
+
+                        // Add delay to prevent Discord rate limiting
+                        await Task.Delay(TimeSpan.FromSeconds(1));
                     }
                     catch (Exception ex)
                     {

--- a/Requestrr.WebApi/RequestrrBot/Notifications/Music/MusicNotificationEngine.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/Music/MusicNotificationEngine.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.Extensions.Logging;
+using Requestrr.WebApi.RequestrrBot.Logging;
 using Requestrr.WebApi.RequestrrBot.Music;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -40,9 +42,13 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.Music
                 while (!_tokenSource.IsCancellationRequested)
                 {
                     Dictionary<string, HashSet<string>> currentRequests = new Dictionary<string, HashSet<string>>();
+                    var cycleStopwatch = Stopwatch.StartNew();
+                    var notifiedCount = 0;
+
                     try
                     {
                         currentRequests = _notificationsRepository.GetAllMusicNotifications();
+                        _logger.LogNotificationStart(Program.DiagnosticsSettings, "Music", currentRequests.Count);
                         Dictionary<string, MusicArtist> availableMusicArtists = await _musicSearcher.SearchAvailableMusicArtistAsync(new HashSet<string>(currentRequests.Keys), _tokenSource.Token);
 
                         foreach (KeyValuePair<string, HashSet<string>> request in currentRequests.Where(x => availableMusicArtists.ContainsKey(x.Key)))
@@ -53,6 +59,7 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.Music
                             try
                             {
                                 HashSet<string> userNotified = await _notifier.NotifyArtistAsync(request.Value.ToArray(), availableMusicArtists[request.Key], _tokenSource.Token);
+                                notifiedCount += userNotified.Count;
 
                                 foreach (string userId in userNotified)
                                 {
@@ -69,6 +76,9 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.Music
                     {
                         _logger.LogError(ex, "An error occurred while retrieving all music notification: " + ex.Message);
                     }
+
+                    cycleStopwatch.Stop();
+                    _logger.LogNotificationCycle(Program.DiagnosticsSettings, "Music", currentRequests.Count, currentRequests.Count, notifiedCount, cycleStopwatch.ElapsedMilliseconds);
 
                     await Task.Delay(TimeSpan.FromMinutes(1), _tokenSource.Token);
                 }

--- a/Requestrr.WebApi/RequestrrBot/Notifications/Music/PrivateMessageMusicNotifier.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/Music/PrivateMessageMusicNotifier.cs
@@ -52,6 +52,9 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.Music
                         {
                             DiscordDmChannel channel = await user.CreateDmChannelAsync();
                             await channel.SendMessageAsync(Language.Current.DiscordNotificationMusicArtistDM.ReplaceTokens(musicArtist), DiscordMusicUserInterface.GenerateMusicArtistDetails(musicArtist));
+
+                            // Add delay to prevent Discord rate limiting
+                            await Task.Delay(TimeSpan.FromSeconds(1));
                         }
                         else
                         {

--- a/Requestrr.WebApi/RequestrrBot/Notifications/Music/PrivateMessageMusicNotifier.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/Music/PrivateMessageMusicNotifier.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Requestrr.WebApi.RequestrrBot.ChatClients.Discord;
 using Requestrr.WebApi.RequestrrBot.Locale;
 using Requestrr.WebApi.RequestrrBot.Music;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/Requestrr.WebApi/RequestrrBot/Notifications/TvShows/ChannelTvShowNotifier.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/TvShows/ChannelTvShowNotifier.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;

--- a/Requestrr.WebApi/RequestrrBot/Notifications/TvShows/ChannelTvShowNotifier.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/TvShows/ChannelTvShowNotifier.cs
@@ -50,6 +50,9 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.TvShows
                     try
                     {
                         await NotifyUsersInChannel(tvShow, seasonNumber, discordUserIds, userNotified, channel);
+
+                        // Add delay to prevent Discord rate limiting
+                        await Task.Delay(TimeSpan.FromSeconds(1));
                     }
                     catch (System.Exception ex)
                     {

--- a/Requestrr.WebApi/RequestrrBot/Notifications/TvShows/PrivateMessageTvShowNotifier.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/TvShows/PrivateMessageTvShowNotifier.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Requestrr.WebApi/RequestrrBot/Notifications/TvShows/PrivateMessageTvShowNotifier.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/TvShows/PrivateMessageTvShowNotifier.cs
@@ -61,6 +61,9 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.TvShows
                                 await channel.SendMessageAsync(Language.Current.DiscordNotificationTvDMSeason.ReplaceTokens(tvShow, seasonNumber), DiscordTvShowUserInterface.GenerateTvShowDetailsAsync(tvShow));
                             else
                                 await channel.SendMessageAsync(Language.Current.DiscordNotificationTvDMFirstEpisode.ReplaceTokens(tvShow, seasonNumber), DiscordTvShowUserInterface.GenerateTvShowDetailsAsync(tvShow));
+
+                            // Add delay to prevent Discord rate limiting
+                            await Task.Delay(TimeSpan.FromSeconds(1));
                         }
                         else
                         {

--- a/Requestrr.WebApi/RequestrrBot/Notifications/TvShows/TvShowNotificationEngine.cs
+++ b/Requestrr.WebApi/RequestrrBot/Notifications/TvShows/TvShowNotificationEngine.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Requestrr.WebApi.RequestrrBot.Logging;
 using Requestrr.WebApi.RequestrrBot.TvShows;
 
 namespace Requestrr.WebApi.RequestrrBot.Notifications.TvShows
@@ -37,10 +39,13 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.TvShows
                 while (!_tokenSource.IsCancellationRequested)
                 {
                     var currentRequests = new Dictionary<int, TvShowNotification[]>();
+                    var cycleStopwatch = Stopwatch.StartNew();
+                    var notifiedCount = 0;
 
                     try
                     {
                         currentRequests = _notificationRequestRepository.GetAllTvShowNotifications();
+                        _logger.LogNotificationStart(Program.DiagnosticsSettings, "TvShow", currentRequests.Count);
                         var tvShows = (await _tvShowSearcher.GetTvShowDetailsAsync(new HashSet<int>(currentRequests.Keys), _tokenSource.Token)).ToDictionary(x => x.TheTvDbId, x => x);
 
                         foreach (var request in currentRequests.Where(x => tvShows.ContainsKey(x.Key)))
@@ -59,6 +64,7 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.TvShows
                                     if (tvShows[request.Key].Seasons.Any(x => x.SeasonNumber == seasonNotifications.Key && x.IsAvailable))
                                     {
                                         var notifiedUsers = await _notifier.NotifyAsync(userIds, tvShows[request.Key], seasonNotifications.Key, _tokenSource.Token);
+                                        notifiedCount += notifiedUsers.Count;
 
                                         foreach (var sentNotification in seasonNotifications.Where(x => notifiedUsers.Contains(x.UserId)))
                                         {
@@ -103,6 +109,9 @@ namespace Requestrr.WebApi.RequestrrBot.Notifications.TvShows
                             }
                         }
                     }
+
+                    cycleStopwatch.Stop();
+                    _logger.LogNotificationCycle(Program.DiagnosticsSettings, "TvShow", currentRequests.Count, currentRequests.Count, notifiedCount, cycleStopwatch.ElapsedMilliseconds);
 
                     await Task.Delay(TimeSpan.FromMinutes(5), _tokenSource.Token);
                 }

--- a/Requestrr.WebApi/RequestrrBot/SlashCommands/SlashCommandBuilder.cs
+++ b/Requestrr.WebApi/RequestrrBot/SlashCommands/SlashCommandBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -41,7 +42,19 @@ namespace Requestrr.WebApi.RequestrrBot
 
         public static Type Build(ILogger logger, DiscordSettings settings, RadarrSettingsProvider radarrSettingsProvider, SonarrSettingsProvider sonarrSettingsProvider, OverseerrSettingsProvider overseerrSettingsProvider, OmbiSettingsProvider ombiSettingsProvider, LidarrSettingsProvider lidarrSettingsProvider)
         {
+            var buildStopwatch = Stopwatch.StartNew();
+
             string code = GetCode(settings, radarrSettingsProvider.Provide(), sonarrSettingsProvider.Provide(), overseerrSettingsProvider.Provide(), ombiSettingsProvider.Provide(), lidarrSettingsProvider.Provider());
+
+            var movieCommands = _commandList.ContainsKey(CommandType.Movie) ? _commandList[CommandType.Movie].Count : 0;
+            var tvCommands = _commandList.ContainsKey(CommandType.Tv) ? _commandList[CommandType.Tv].Count : 0;
+            var musicCommands = _commandList.ContainsKey(CommandType.Music) ? _commandList[CommandType.Music].Count : 0;
+            var issueCommands = (_commandList.ContainsKey(CommandType.IssueMovie) ? _commandList[CommandType.IssueMovie].Count : 0) +
+                               (_commandList.ContainsKey(CommandType.IssueTv) ? _commandList[CommandType.IssueTv].Count : 0);
+            var miscCommands = _commandList.ContainsKey(CommandType.Misc) ? _commandList[CommandType.Misc].Count : 0;
+
+            logger.LogInformation($"Building slash commands: {movieCommands} movie, {tvCommands} tv, {musicCommands} music, {issueCommands} issue, {miscCommands} misc");
+
             var tree = SyntaxFactory.ParseSyntaxTree(code);
             string fileName = $"{DLLFileName}-{Guid.NewGuid()}.dll";
 
@@ -79,14 +92,27 @@ namespace Requestrr.WebApi.RequestrrBot
 
             string path = Path.Combine(TempFolder, fileName);
 
+            var compileStopwatch = Stopwatch.StartNew();
             var compilationResult = compilation.Emit(path);
+            compileStopwatch.Stop();
+
             if (compilationResult.Success)
             {
+                logger.LogInformation($"SlashCommand compilation completed in {compileStopwatch.ElapsedMilliseconds}ms");
+
+                var loadStopwatch = Stopwatch.StartNew();
                 var asm = AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
-                return asm.GetType("Requestrr.WebApi.RequestrrBot.SlashCommands");
+                var type = asm.GetType("Requestrr.WebApi.RequestrrBot.SlashCommands");
+                loadStopwatch.Stop();
+
+                buildStopwatch.Stop();
+                logger.LogInformation($"SlashCommand assembly loaded in {loadStopwatch.ElapsedMilliseconds}ms, total build time: {buildStopwatch.ElapsedMilliseconds}ms");
+
+                return type;
             }
             else
             {
+                logger.LogError($"SlashCommand compilation failed after {compileStopwatch.ElapsedMilliseconds}ms");
                 foreach (Diagnostic codeIssue in compilationResult.Diagnostics)
                 {
                     string issue = $"ID: {codeIssue.Id}, Message: {codeIssue.GetMessage()}, Location: {codeIssue.Location.GetLineSpan()},Severity: {codeIssue.Severity}";

--- a/Requestrr.WebApi/RequestrrBot/TvShows/TvShowWorkflowFactory.cs
+++ b/Requestrr.WebApi/RequestrrBot/TvShows/TvShowWorkflowFactory.cs
@@ -21,6 +21,7 @@ namespace Requestrr.WebApi.RequestrrBot.TvShows
         private OverseerrClient _overseerrClient;
         private OmbiClient _ombiDownloadClient;
         private SonarrClient _sonarrDownloadClient;
+        private readonly ILogger _logger;
 
         public TvShowWorkflowFactory(
             TvShowsSettingsProvider tvShowsSettingsProvider,
@@ -28,7 +29,8 @@ namespace Requestrr.WebApi.RequestrrBot.TvShows
             TvShowNotificationsRepository notificationsRepository,
             OverseerrClient overseerrClient,
             OmbiClient ombiDownloadClient,
-            SonarrClient radarrDownloadClient)
+            SonarrClient radarrDownloadClient,
+            ILogger logger)
         {
             _tvShowsSettingsProvider = tvShowsSettingsProvider;
             _settingsProvider = settingsProvider;
@@ -36,6 +38,7 @@ namespace Requestrr.WebApi.RequestrrBot.TvShows
             _overseerrClient = overseerrClient;
             _ombiDownloadClient = ombiDownloadClient;
             _sonarrDownloadClient = radarrDownloadClient;
+            _logger = logger;
         }
 
         public TvShowRequestingWorkflow CreateRequestingWorkflow(DiscordInteraction interaction, int categoryId)

--- a/Requestrr.WebApi/appsettings.json
+++ b/Requestrr.WebApi/appsettings.json
@@ -1,7 +1,10 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.AspNetCore": "Warning",
+      "System": "Warning"
     }
   },
   "AllowedHosts": "*",

--- a/Requestrr.WebApi/config/DiagnosticsSettings.cs
+++ b/Requestrr.WebApi/config/DiagnosticsSettings.cs
@@ -1,0 +1,40 @@
+namespace Requestrr.WebApi.config
+{
+    public enum DiagnosticsLevel
+    {
+        Default = 0,  // No diagnostic logging
+        Info = 1,     // Essential diagnostics (connections, slash commands, notification cycles)
+        Verbose = 2   // Everything (HTTP requests, heartbeats, all details)
+    }
+
+    public class DiagnosticsSettings
+    {
+        public DiagnosticsLevel Level { get; set; } = DiagnosticsLevel.Default;
+
+        // Helper methods for level-based checks
+        public bool ShouldLogHttpFor(string clientType)
+        {
+            return Level == DiagnosticsLevel.Verbose;
+        }
+
+        public bool ShouldLogDiscordHeartbeat()
+        {
+            return Level == DiagnosticsLevel.Verbose;
+        }
+
+        public bool ShouldLogDiscordSlashCommands()
+        {
+            return Level >= DiagnosticsLevel.Info;
+        }
+
+        public bool ShouldLogDiscordConnections()
+        {
+            return Level >= DiagnosticsLevel.Info;
+        }
+
+        public bool ShouldLogNotificationCycle(string type)
+        {
+            return Level >= DiagnosticsLevel.Info;
+        }
+    }
+}

--- a/Requestrr.WebApi/docker-compose.yml
+++ b/Requestrr.WebApi/docker-compose.yml
@@ -8,4 +8,10 @@ services:
     - 4545:4545
     volumes:
     - /path to config:/root/config
+    environment:
+      # Diagnostic Logging Level
+      # default - No diagnostic logging (production mode)
+      # info    - Essential diagnostics: Discord connections, slash commands, notification cycles
+      # verbose - Full diagnostics: All of info + HTTP requests, heartbeats
+      - REQUESTRR_DIAGNOSTICS_LEVEL=default
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Adds a configurable diagnostic logging system controlled by a single environment variable `REQUESTRR_DIAGNOSTICS_LEVEL` with three levels: default, info, and verbose.

## Motivation

This feature allows users to control the verbosity of diagnostic logs without code changes, making it easier to:
- Run in production with clean logs (default)
- Monitor system health (info)  
- Troubleshoot issues and investigate performance (verbose)

## Changes

### Three Diagnostic Levels

**default** - No diagnostic logging (production mode)
- Only standard application logs

**info** - Essential diagnostics  
- Discord connection events
- Slash command registration details
- Notification cycle summaries (items checked, notifications sent, duration)

**verbose** - Full diagnostics
- Everything from info level
- HTTP requests to all download clients (Radarr, Sonarr, Ombi, Lidarr, Overseerr)
- Response times and status codes for performance monitoring
- Discord heartbeat messages

### Configuration

Set in docker-compose.yml:
```yaml
environment:
  - REQUESTRR_DIAGNOSTICS_LEVEL=default  # or info, or verbose
```

### Implementation

- Created `DiagnosticsSettings` class with hierarchical logging control
- Extended HTTP request logging to all download clients with Stopwatch timing
- Made Discord bot logging (connections, heartbeats, slash commands) conditional
- Made notification cycle logging conditional
- All logging checks diagnostic level before writing

### Files Modified

**Core Infrastructure:**
- `Requestrr.WebApi/config/DiagnosticsSettings.cs` (new)
- `Requestrr.WebApi/Program.cs`
- `Requestrr.WebApi/RequestrrBot/Logging/LoggingExtensions.cs`

**Discord Logging:**
- `Requestrr.WebApi/RequestrrBot/ChatBot.cs`

**Notification Engines:**
- `Requestrr.WebApi/RequestrrBot/Notifications/Movies/MovieNotificationEngine.cs`
- `Requestrr.WebApi/RequestrrBot/Notifications/TvShows/TvShowNotificationEngine.cs`
- `Requestrr.WebApi/RequestrrBot/Notifications/Music/MusicNotificationEngine.cs`

**HTTP Download Clients:**
- `Requestrr.WebApi/RequestrrBot/DownloadClients/Overseerr/OverseerrClient.cs`
- `Requestrr.WebApi/RequestrrBot/DownloadClients/Ombi/OmbiClient.cs`
- `Requestrr.WebApi/RequestrrBot/DownloadClients/Lidarr/LidarrClientV1.cs`
- `Requestrr.WebApi/RequestrrBot/DownloadClients/Radarr/RadarrClientV2.cs`
- `Requestrr.WebApi/RequestrrBot/DownloadClients/Radarr/RadarrClientV3.cs`
- `Requestrr.WebApi/RequestrrBot/DownloadClients/Sonarr/SonarrClientV2.cs`
- `Requestrr.WebApi/RequestrrBot/DownloadClients/Sonarr/SonarrClientV3.cs`
- `Requestrr.WebApi/RequestrrBot/DownloadClients/Sonarr/SonarrClientV4.cs`

**Configuration:**
- `Requestrr.WebApi/docker-compose.yml`

## Test Plan

Tested all three levels on live docker stack:

- **default**: Verified no diagnostic logs appear
- **info**: Confirmed Discord connections, slash commands, and notification cycles log
- **verbose**: Verified HTTP API requests log with timing (e.g., `Overseerr API: POST http://seerr:5055/api/v1/request - 201 Created in 24ms`)

## Example Output

### Info Level
```
Discord bot connected to 1 guilds, Latency: 134ms
Registered guild-specific slash commands for guild 966607239441940491
Movie notification cycle: Checked 4, Available 4, Sent 0 in 102ms
```

### Verbose Level
```
Discord bot connected to 1 guilds, Latency: 134ms
Heartbeat received, Latency: 126ms
Registered guild-specific slash commands for guild 966607239441940491
Movie notification cycle: Checked 4, Available 4, Sent 0 in 81ms
Overseerr API: POST http://seerr:5055/api/v1/request - 201 Created in 24ms
```

## Breaking Changes

None. Defaults to no diagnostic logging (current behavior).

## Related Issues

Helps with troubleshooting Discord bot issues, API performance monitoring, and rate limiting investigation.